### PR TITLE
Use license instead of licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can learn more about contributing via GitHub in our [contribution guidelines
 
 License
 -------
-Code is under the [Apache Licence v2](https://www.apache.org/licenses/LICENSE-2.0.txt).
+Code is under the [Apache License v2](https://www.apache.org/licenses/LICENSE-2.0.txt).
 
 Donations
 ---------


### PR DESCRIPTION
Noticed in Imaging that the README said Apache Licence... but reading the original license text, is actually says Apache License. So I think we should stick with license? Not a native speaker, and living in a commonwealth country, so licence would be fine for me, but I think this makes more sense?