### PR TITLE
[COMMONSSITE-156] Reviewing Release Plug-in post Imaging 1.0-alpha3 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -688,7 +688,7 @@
                 </goals>
               </execution>
               <execution>
-                <id>detatch-distributions</id>
+                <id>detach-distributions</id>
                 <phase>verify</phase>
                 <goals>
                   <goal>detach-distributions</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -644,7 +644,7 @@
                 </goals>
                 <phase>pre-site</phase>
                 <configuration>
-                  <tasks>
+                  <target>
                     <exec executable="svn">
                       <arg line="checkout --depth immediates ${commons.scmPubUrl} ${commons.scmPubCheckoutDirectory}"/>
                     </exec>
@@ -659,7 +659,7 @@
                     <exec executable="svn">
                       <arg line="update --set-depth infinity ${dirs}"/>
                     </exec>
-                  </tasks>
+                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/java/org/apache/commons/release/plugin/SharedFunctions.java
+++ b/src/main/java/org/apache/commons/release/plugin/SharedFunctions.java
@@ -40,12 +40,6 @@ import org.codehaus.plexus.util.FileUtils;
 public final class SharedFunctions {
 
     /**
-     * I want a buffer that is an array with 1024 elements of bytes. We declare
-     * the constant here for the sake of making the code more readable.
-     */
-    public static final int BUFFER_BYTE_SIZE = 1024;
-
-    /**
      * Copies a {@link File} from the <code>fromFile</code> to the <code>toFile</code> and logs the failure
      * using the Maven {@link Log}.
      *
@@ -71,7 +65,7 @@ public final class SharedFunctions {
      * Cleans and then initializes an empty directory that is given by the <code>workingDirectory</code>
      * parameter.
      *
-     * @param log is the Maven log for output logging, particularly in regards to error management.
+     * @param log is the Maven log for output logging, particularly in regard to error management.
      * @param workingDirectory is a {@link File} that represents the directory to first attempt to delete then create.
      * @throws MojoExecutionException when an {@link IOException} or {@link NullPointerException} is caught for the
      *      purpose of bubbling the exception up to Maven properly.
@@ -94,60 +88,9 @@ public final class SharedFunctions {
     }
 
     /**
-     * Checks that the specified object reference is not {@code null}. This method is designed primarily for doing parameter validation in methods and
-     * constructors, as demonstrated below: <blockquote>
-     *
-     * <pre>
-     * public Foo(Bar bar) {
-     *     this.bar = SharedFunctions.requireNonNull(bar);
-     * }
-     * </pre>
-     *
-     * </blockquote>
-     *
-     * @param obj the object reference to check for nullity
-     * @param <T> the type of the reference
-     * @return {@code obj} if not {@code null}
-     * @throws MojoExecutionException if {@code obj} is {@code null}
-     */
-    public static <T> T requireNonNull(final T obj) throws MojoExecutionException {
-        if (obj == null) {
-            throw new MojoExecutionException(new NullPointerException());
-        }
-        return obj;
-    }
-
-    /**
-     * Checks that the specified object reference is not {@code null} and throws a customized {@link MojoExecutionException} if it is. This method is designed
-     * primarily for doing parameter validation in methods and constructors with multiple parameters, as demonstrated below: <blockquote>
-     *
-     * <pre>
-     * public Foo(Bar bar, Baz baz) {
-     *     this.bar = SharedFunctions.requireNonNull(bar, "bar must not be null");
-     *     this.baz = SharedFunctions.requireNonNull(baz, "baz must not be null");
-     * }
-     * </pre>
-     *
-     * </blockquote>
-     *
-     * @param obj the object reference to check for nullity
-     * @param message detail message to be used in the event that a {@code
-     *                NullPointerException} is thrown
-     * @param <T> the type of the reference
-     * @return {@code obj} if not {@code null}
-     * @throws MojoExecutionException if {@code obj} is {@code null}
-     */
-    public static <T> T requireNonNull(final T obj, final String message) throws MojoExecutionException {
-        if (obj == null) {
-            throw new MojoExecutionException(new NullPointerException(message));
-        }
-        return obj;
-    }
-
-    /**
      * Checks that the specified object reference is not {@code null} and throws a customized {@link MojoExecutionException} if it is.
      * <p>
-     * Unlike the method {@link #requireNonNull(Object, String)}, this method allows creation of the message to be deferred until after the null check is made.
+     * This method allows creation of the message to be deferred until after the null check is made.
      * While this may confer a performance advantage in the non-null case, when deciding to call this method care should be taken that the costs of creating the
      * message supplier are less than the cost of just creating the string message directly.
      * </p>

--- a/src/main/java/org/apache/commons/release/plugin/SharedFunctions.java
+++ b/src/main/java/org/apache/commons/release/plugin/SharedFunctions.java
@@ -55,7 +55,7 @@ public final class SharedFunctions {
      * @throws MojoExecutionException if an {@link IOException} or {@link NullPointerException} is caught.
      */
     public static void copyFile(final Log log, final File fromFile, final File toFile) throws MojoExecutionException {
-        final String format = "Unable to copy file %s tp %s: %s";
+        final String format = "Unable to copy file %s to %s: %s";
         requireNonNull(fromFile, () -> String.format(format, fromFile, toFile));
         requireNonNull(toFile, () -> String.format(format, fromFile, toFile));
         try {

--- a/src/main/java/org/apache/commons/release/plugin/SharedFunctions.java
+++ b/src/main/java/org/apache/commons/release/plugin/SharedFunctions.java
@@ -56,8 +56,8 @@ public final class SharedFunctions {
      */
     public static void copyFile(final Log log, final File fromFile, final File toFile) throws MojoExecutionException {
         final String format = "Unable to copy file %s to %s: %s";
-        requireNonNull(fromFile, () -> String.format(format, fromFile, toFile));
-        requireNonNull(toFile, () -> String.format(format, fromFile, toFile));
+        requireNonNull(fromFile, () -> String.format(format, fromFile, toFile, "Missing fromFile argument"));
+        requireNonNull(toFile, () -> String.format(format, fromFile, toFile, "Missing toFile argument"));
         try {
             FileUtils.copyFile(fromFile, toFile);
         } catch (final IOException e) {
@@ -78,7 +78,7 @@ public final class SharedFunctions {
      */
     public static void initDirectory(final Log log, final File workingDirectory) throws MojoExecutionException {
         final String format = "Unable to remove directory %s: %s";
-        requireNonNull(workingDirectory, () -> String.format(format, workingDirectory));
+        requireNonNull(workingDirectory, () -> String.format(format, workingDirectory, "Missing workingDirectory argument"));
         if (workingDirectory.exists()) {
             try {
                 FileUtils.deleteDirectory(workingDirectory);

--- a/src/main/java/org/apache/commons/release/plugin/mojos/CommonsDistributionDetachmentMojo.java
+++ b/src/main/java/org/apache/commons/release/plugin/mojos/CommonsDistributionDetachmentMojo.java
@@ -240,7 +240,7 @@ public class CommonsDistributionDetachmentMojo extends AbstractMojo {
                 try {
                     final String digest;
                     // SHA-512
-                    digest = artifactSha512s.getProperty(artifactKey.toString());
+                    digest = artifactSha512s.getProperty(artifactKey);
                     getLog().info(artifact.getFile().getName() + " sha512: " + digest);
                     try (PrintWriter printWriter = new PrintWriter(
                             getSha512FilePath(workingDirectory, artifact.getFile()))) {
@@ -270,7 +270,7 @@ public class CommonsDistributionDetachmentMojo extends AbstractMojo {
 
     /**
      * Generates the unique artifact key for storage in our sha512 map. For example,
-     * commons-test-1.4-src.tar.gz should have it's name as the key.
+     * commons-test-1.4-src.tar.gz should have its name as the key.
      *
      * @param artifact the {@link Artifact} that we wish to generate a key for.
      * @return the generated key

--- a/src/main/java/org/apache/commons/release/plugin/mojos/CommonsSiteCompressionMojo.java
+++ b/src/main/java/org/apache/commons/release/plugin/mojos/CommonsSiteCompressionMojo.java
@@ -65,7 +65,7 @@ public class CommonsSiteCompressionMojo extends AbstractMojo {
     private File siteDirectory;
 
     /**
-     * The url of the subversion repository to which we wish the artifacts to be staged. Typicallly
+     * The url of the subversion repository to which we wish the artifacts to be staged. Typically,
      * this would need to be of the form:
      * <code>scm:svn:https://dist.apache.org/repos/dist/dev/commons/foo</code>. Note. that the prefix to the
      * substring <code>https</code> is a requirement.

--- a/src/main/java/org/apache/commons/release/plugin/mojos/CommonsStagingCleanupMojo.java
+++ b/src/main/java/org/apache/commons/release/plugin/mojos/CommonsStagingCleanupMojo.java
@@ -45,8 +45,8 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * This class checks out the dev distribution location, checkes whether anything exists in the
- * distribution location, and if it is non-empty it deletes all of the resources there.
+ * This class checks out the dev distribution location, checks whether anything exists in the
+ * distribution location, and if it is non-empty it deletes all the resources there.
  *
  * @author chtompki
  * @since 1.6
@@ -72,15 +72,15 @@ public class CommonsStagingCleanupMojo extends AbstractMojo {
     private File workingDirectory;
 
     /**
-     * The location to which to checkout the dist subversion repository under our working directory, which
-     * was given above. We then do an SVN delete on all of the directories in this repository.
+     * The location to which to check out the dist subversion repository under our working directory, which
+     * was given above. We then do an SVN delete on all the directories in this repository.
      */
     @Parameter(defaultValue = "${project.build.directory}/commons-release-plugin/scm-cleanup",
             property = "commons.distCleanupDirectory")
     private File distCleanupDirectory;
 
     /**
-     * A boolean that determines whether or not we actually commit the files up to the subversion repository.
+     * A boolean that determines whether we actually commit the files up to the subversion repository.
      * If this is set to <code>true</code>, we do all but make the commits. We do checkout the repository in question
      * though.
      */
@@ -88,7 +88,7 @@ public class CommonsStagingCleanupMojo extends AbstractMojo {
     private Boolean dryRun;
 
     /**
-     * The url of the subversion repository to which we wish the artifacts to be staged. Typically this would need to
+     * The url of the subversion repository to which we wish the artifacts to be staged. Typically, this would need to
      * be of the form: <code>scm:svn:https://dist.apache.org/repos/dist/dev/commons/foo/version-RC#</code>. Note. that
      * the prefix to the substring <code>https</code> is a requirement.
      */

--- a/src/main/resources/org/apache/commons/release/plugin/velocity/README.vm
+++ b/src/main/resources/org/apache/commons/release/plugin/velocity/README.vm
@@ -33,12 +33,12 @@
 <p>From the Apache Commons Project<br><a href="https://commons.apache.org/">https://commons.apache.org/</a></p>
 
 <h2><a name="mirrors">Download from your
-    <a href="http://www.apache.org/dyn/closer.cgi/commons/">nearest mirror site!</a></a></h2>
+    <a href="https://www.apache.org/dyn/closer.cgi/commons/">nearest mirror site!</a></a></h2>
 
 <p>
     Do not download from www.apache.org.  Please use a mirror site
     to help us save apache.org bandwidth.
-    <a href="http://www.apache.org/dyn/closer.cgi/commons/">Go
+    <a href="https://www.apache.org/dyn/closer.cgi/commons/">Go
         here to find your nearest mirror.</a>
 </p>
 
@@ -48,7 +48,7 @@
     there will be an accompanying <samp><em>file</em>.asc</samp> signature
     file in the same directory as the file (binaries/ or source/).  The
     signing keys can be found in the distribution directory at &lt;<a
-            HREF="http://downloads.apache.org/commons/KEYS"><samp>http://downloads.apache.org/commons/KEYS</samp></a>&gt;.</p>
+            HREF="https://downloads.apache.org/commons/KEYS"><samp>https://downloads.apache.org/commons/KEYS</samp></a>&gt;.</p>
 
 <p><b>Always download the KEYS file directly from the Apache site, never from a mirror site.</b></p>
 

--- a/src/site/xdoc/development.xml
+++ b/src/site/xdoc/development.xml
@@ -30,8 +30,8 @@
 
       <p>
         The best sources of information are
-        <a href="http://maven.apache.org/guides/plugin/guide-java-plugin-development.html">Developing Java Plugins for Maven 3.x</a>
-        and <a href="http://www.sonatype.com/book/chapter-11.html">Maven: The Definitive Guide: Chapter 11 Writing Plugins</a>.
+        <a href="https://maven.apache.org/guides/plugin/guide-java-plugin-development.html">Developing Java Plugins for Maven 3.x</a>
+        and <a href="https://www.sonatype.com/book/chapter-11.html">Maven: The Definitive Guide: Chapter 11 Writing Plugins</a>.
       </p>
 
     </section>

--- a/src/site/xdoc/download_release-plugin.xml
+++ b/src/site/xdoc/download_release-plugin.xml
@@ -78,8 +78,8 @@ limitations under the License.
         mirror.  If all mirrors are failing, there are <i>backup</i>
         mirrors (at the end of the mirrors list) that should be
         available.
-        <br></br>
-        [if-any logo]<a href="[link]"><img align="right" src="[logo]" border="0"></img></a>[end]
+        <br />
+        [if-any logo]<a href="[link]"><img align="right" src="[logo]" border="0" /></a>[end]
       </p>
 
       <form action="[location]" method="get" id="SelectMirror">

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -31,7 +31,7 @@
         <section name="Release Plugin">
 
             <p>
-            This is a <a href="http://maven.apache.org/">Maven 3.x</a> Plugin which is
+            This is a <a href="https://maven.apache.org/">Maven 3.x</a> Plugin which is
             used by <a href="https://commons.apache.org/">Apache Commons</a> releases. See
             the <a href="development.html">Development</a> page for information to
             help maintain this plugin.

--- a/src/site/xdoc/vote-txt.xml
+++ b/src/site/xdoc/vote-txt.xml
@@ -41,11 +41,11 @@
                 This goal uses the following:
                 <ul>
                     <li>The goal is mapped to the ant script/target using the <code>vote-txt</code> mojo defintion in the
-                        <a href="http://svn.apache.org/repos/asf/commons/proper/commons-release-plugin/trunk/src/main/scripts/generate-xdocs.mojos.xml">generate-xdocs.mojos.xml</a> mapping document</li>
+                        <a href="https://svn.apache.org/repos/asf/commons/proper/commons-release-plugin/trunk/src/main/scripts/generate-xdocs.mojos.xml">generate-xdocs.mojos.xml</a> mapping document</li>
                     <li>Executes the <code>vote-txt</code> target in
-                        <a href="http://svn.apache.org/repos/asf/commons/proper/commons-release-plugin/trunk/src/main/scripts/generate-xdocs.build.xml">generate-xdocs.build.xml</a>
+                        <a href="https://svn.apache.org/repos/asf/commons/proper/commons-release-plugin/trunk/src/main/scripts/generate-xdocs.build.xml">generate-xdocs.build.xml</a>
                         ant script</li>
-                    <li>Uses the <a href="http://svn.apache.org/repos/asf/commons/proper/commons-release-plugin/trunk/src/main/resources/commons-xdoc-templates/vote-txt-template.md">vote-txt-template.md</a>
+                    <li>Uses the <a href="https://svn.apache.org/repos/asf/commons/proper/commons-release-plugin/trunk/src/main/resources/commons-xdoc-templates/vote-txt-template.md">vote-txt-template.md</a>
                         template</li>
                     <li>Uses the <a href="vote-txt-mojo.html">goal's (i.e. mojo's) parameters</a> to filter values in the template</li>
                 </ul>

--- a/src/test/resources/mojos/compress-site/example-site/index.html
+++ b/src/test/resources/mojos/compress-site/example-site/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file

--- a/src/test/resources/mojos/detach-distributions/target/site/index.html
+++ b/src/test/resources/mojos/detach-distributions/target/site/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file

--- a/src/test/resources/mojos/detach-distributions/target/site/subdirectory/index.html
+++ b/src/test/resources/mojos/detach-distributions/target/site/subdirectory/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Had a few hiccups during the last release of Imaging, so I'm sending this PR to the Release Plug-in, and will prepare a SVN patch for the Commons CMS site.

- [x] typos
- [x] fixing HTML tags (e.g. adding `lang="en"` as it's recommended for accessibility)
- [x] remove unused methods in the plug-in (not deprecated, but actually not used anywhere within this code base)
- [x] fixing an issue found in the imaging release when running `mvn site` due to a change in the parent
- [x] use HTTPS when possible
- [ ] fixing RAT, pending the 0.14 release of their maven plug-in (<https://github.com/apache/commons-imaging/blob/de0dda58cdabb5c22c6c2596dfa085262ce64840/pom.xml#L29-L32>)
  * <https://issues.apache.org/jira/browse/RAT-297>
  * <https://issues.apache.org/jira/browse/MSHARED-1049>

The last part about RAT is a nice to have. At the moment the plug-in is failing to run when you run `mvn site`, but it doesn't break the build.

The reason is that the RAT plug-in had been using a deprecated call for years, that was eventually removed from the Maven toolkit. Once they release the 0.14 release with the fix it should be fixed. So in other words, at the moment RAT plug-in is not working in the Release Plug-in, but you are able to run `mvn apache-rat:check` and `mvn apache-rat:rat`.

I think this can be merged as-is, and the RAT issue moved to its own issue (or we can downgrade to parent 52)